### PR TITLE
WCAG replacing FAST

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -26,6 +26,11 @@ Markup Shorthands: markdown yes
     "title": "Framework for Accessibility in the Specification of Technologies",
     "publisher": "W3C Accessible Platform Architectures Working Group"
 },
+  "WCAG": {
+    "href": "https://www.w3.org/TR/WCAG21",
+    "title": "Web Content Accessibility Guidelines (WCAG) 2.1",
+    "publisher": "W3C Accessible Platform Architectures Working Group"
+},
   "CDEI": {
      "href":
      "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/938857/Summary_Slide_Deck_-_CDEI_review_into_bias_in_algorithmic_decision-making.pdf",
@@ -359,7 +364,7 @@ ML actors should minimize and avoid reinforcing or perpetuating bias and discrim
 
 This principle also applies to access to web ML systems: they should be fully accessible to people with disabilities, appropriately localized, and accommodate people on low bandwidth networks and with low specification equipment. 
 
-For further guidance on accessibility, see  the draft checklist to support Framework for Accessibility in the Specification of Technologies [[FAST]].
+For further guidance on accessibility, see the Web Content Accessibility Guidelines (WCAG) 2.1 [[WCAG]], or consult the Accessible Platform Architectures (APA) Working Group.
 
 
 <h4 class=no-num>PRINCIPLE 3) Autonomy</h4>

--- a/index.bs
+++ b/index.bs
@@ -29,7 +29,7 @@ Markup Shorthands: markdown yes
   "WCAG": {
     "href": "https://www.w3.org/TR/WCAG21",
     "title": "Web Content Accessibility Guidelines (WCAG) 2.1",
-    "publisher": "W3C Accessible Platform Architectures Working Group"
+    "publisher": "W3C Accessibility Guidelines Working Group"
 },
   "CDEI": {
      "href":


### PR DESCRIPTION
@anssiko this change is in response to https://github.com/webmachinelearning/ethical-webmachinelearning/issues/10

I'll outline the rationale in the issue thread, if every is happy can you review this?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/ethical-webmachinelearning/pull/13.html" title="Last updated on May 3, 2022, 1:19 PM UTC (ffe92f1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/ethical-webmachinelearning/13/62a5765...ffe92f1.html" title="Last updated on May 3, 2022, 1:19 PM UTC (ffe92f1)">Diff</a>