### PR TITLE
Fairness & outliers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -355,7 +355,7 @@ ML actors should prioritize potential benefits for users over potential benefits
 
 The benefits of ML systems should be available and accessible to all.
 
-ML actors should minimize and avoid reinforcing or perpetuating bias and discrimination, particularly against vulnerable and historically marginalised groups.They should ensure that the outcomes of ML applications are fair, and that effective remedy is available against discrimination and biased algorithmic determination.
+ML actors should minimize and avoid reinforcing or perpetuating bias and discrimination, particularly against vulnerable and historically marginalised groups.They should ensure that the outcomes of ML applications are fair, and that effective remedy is available against discrimination and biased algorithmic determination. ML systems should work equally well for all users, and where this is not true for 'outliers', fallback solutions should be provided.
 
 This principle also applies to access to web ML systems: they should be fully accessible to people with disabilities, appropriately localized, and accommodate people on low bandwidth networks and with low specification equipment. 
 


### PR DESCRIPTION
Response to this comment from Brainstorm 1 in the Fairness section "ML works very well when applied to people in the center of the curve but outliers will probably find themselves excluded and it’s important orgs using ML provide fallback solutions for these inevitabilities."

This echoes the concerns expressed by e.g. Jutta Treviranus earlier in the Working Group process, and is worth adding to the fairness sections.

I've added the following text: "ML systems should work equally well for all users, and where this is not true for 'outliers', fallback solutions should be provided."