### PR TITLE
Explainability of WebML API

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -393,7 +393,7 @@ Users and third-parties such as civil society groups and researchers should be a
 
 ML actors should inform users when a product or service is provided directly or with the assistance of ML, and users should be fully informed when a significant decision is informed by or is made on the basis of ML. They should be able to access the reasons for a decision affecting their rights and freedoms, and ML actors should provide means for users to request review and correction of these decisions.
 
-ML systems and outcomes should be explainable. ML actors should promote tools and approaches that enhance explainability and meaningful user control.
+ML systems and outcomes should be explainable. ML actors should also provide clear explantions of the benefits and risks of different ways of accessing ML capabilities (e.g. client vs server-side inference). ML actors should promote tools and approaches that enhance explainability and meaningful user control.
 
 ML actors should also be transparent about the steps they have taken to consider and implement these ethical principles. 
 


### PR DESCRIPTION
Added the following to guidance for Transparency and Explainability:

"ML actors should also provide clear explanations of the benefits and risks of different ways of accessing ML capabilities (e.g. client vs server-side inference)."

This is in response to Jonathan Bingham's input in the brainstorming session:

"I’m thinking here about how to explain what the Web ML APIs themselves do, and what the tradeoffs are to running ML in the browser vs what the web app would do instead, like run the same or different ML on the server."

"The difficulty of explaining Web ML’s benefits and drawbacks may lead people to make choices that are worse for them. Eg, they might turn off Web ML, not understanding that it’s better for privacy to keep the data local. (I’m thinking here about the transparency and explainability of the API, not the ML model.)"


